### PR TITLE
added error message if missing-http not installed/on path

### DIFF
--- a/+alyx/loginWindow.m
+++ b/+alyx/loginWindow.m
@@ -10,6 +10,10 @@ username = [];
 
 
 while ~loginSuccessful
+    
+    if isempty(strfind(lower(path),lower('missing-http-1.0.0')))
+        error('missing-http toolbox not found. is it installed and on the path?')
+    end
 
     if nargin < 1
         prompt = {'Alyx username:'};
@@ -39,4 +43,5 @@ while ~loginSuccessful
     if ~isempty(alyxInstance)
         loginSuccessful = true;
     end
+    
 end


### PR DESCRIPTION
previously the login window would stay in a while loop if the missing-http toolbox was not found (i.e. not installed or not on path), with no indication that this was the problem. 

this commit searches for the toolbox on the path and sends an error if it is not found (there may be a better implementation) 