### PR TITLE
fixed queuing error (this is andy posting from laura's account)

### DIFF
--- a/+alyx/flushQueue.m
+++ b/+alyx/flushQueue.m
@@ -52,8 +52,6 @@ function [data,statusCode] = flushQueue(alyxInstance)
             
             % If the JSON command failed (e.g. internet is down)
             warning(['JSON command failed - saved in queue']);
-            data = [];
-            statusCode = [];
             
         end
         


### PR DESCRIPTION
fixed issue where first queued command failed and then an output structure was off (specifically, 'data' was set to an empty array on failure but is a struct on success, so if there's a failure first then there's a datatype problem if the next is a success)