### PR TITLE
re-order the constructor so that dat.paths URL is used

### DIFF
--- a/@Alyx/Alyx.m
+++ b/@Alyx/Alyx.m
@@ -55,16 +55,19 @@ classdef Alyx
   methods
     function obj = Alyx(user, token)
       %ALYX Class constructor
+      
+      % Set the directory and URL paths
+      p = dat.paths;
+      obj.BaseURL = getOr(p, 'databaseURL', obj.BaseURL);
+      obj.QueueDir = getOr(p, 'localAlyxQueue', obj.QueueDir);
+      
       if nargin
         obj.User = user;
         obj.Token = token;
       else
         obj = obj.login;
       end
-      % Set the directory and URL paths
-      p = dat.paths;
-      obj.BaseURL = getOr(p, 'databaseURL', obj.BaseURL);
-      obj.QueueDir = getOr(p, 'localAlyxQueue', obj.QueueDir);
+      
     end
     
     function obj = logout(obj)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## [Latest](https://github.com/cortex-lab/matlab-ci/commits/master) [2.0.1]
+
+### Added
+
+### Modified
+
+- Patch fix for class constructor default url used instead of paths


### PR DESCRIPTION
As it was previously, it will try to use cortexlab.net (the default) even if you have correctly specified a different URL in dat.paths, since the obj.login was coming before the URL stuff. 