### PR TITLE
2.6.0

### DIFF
--- a/@Alyx/getToken.m
+++ b/@Alyx/getToken.m
@@ -22,7 +22,7 @@ if statusCode == 200
 elseif statusCode == 000
   % Alyx is down, set as headless
   obj.Headless = true;
-  return
+  error('Alyx:Login:FailedToConnect', responseBody)
 elseif statusCode == 400 && isempty(password)
   error('Alyx:Login:PasswordEmpty', 'Password may not be left blank')
 else

--- a/@Alyx/login.m
+++ b/@Alyx/login.m
@@ -51,6 +51,9 @@ while ~obj.IsLoggedIn
       % JSONlab not installed
       error(ex.identifier, 'JSONLab Toolbox required.  Click <a href="matlab:web(''%s'',''-browser'')">here</a> to install.',...
         'https://uk.mathworks.com/matlabcentral/fileexchange/33381-jsonlab--a-toolbox-to-encode-decode-json-files')
+    elseif strcmp(ex.identifier, 'Alyx:Login:FailedToConnect')
+       obj.Headless = true;
+       break
     elseif contains(ex.message, 'credentials')||strcmpi(ex.message, 'Bad Request')
       if obj.Headless == true
         warning('Alyx:LoginFail:BadCredentials', 'Unable to log in with provided credentials.')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 **NB:** Versioning became consistent only after v2.1.0, before this many patches went unrecorded.
 
-## [Latest](https://github.com/cortex-lab/alyx-matlab/commits/master) [2.5.0]
+## [Latest](https://github.com/cortex-lab/alyx-matlab/commits/master) [2.6.0]
+
+- Better handling of headless state on login
+
+## [2.5.0]
 
 - Fix for multiple base session creation; removed testDev database (`4d6f6bc`)
 - Improvements to madeEndpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Latest](https://github.com/cortex-lab/alyx-matlab/commits/master) [2.6.0]
 
 - Better handling of headless state on login
+- Save timeline ALF files as _timeline_DAQdata object
 
 ## [2.5.0]
 


### PR DESCRIPTION
- Better handling of headless state on login
- Save timeline ALF files as _timeline_DAQdata object